### PR TITLE
Add example of custom paths in Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ services:
       - 8188:8188
     volumes:
       - ./run:/comfy/mnt
+      # Optional: Separate models, workflows, and outputs to safely delete the run folder without loss.
+      - ./models:/comfy/mnt/ComfyUI/models
+      - ./workflows:/comfy/mnt/ComfyUI/user/default/workflows
+      - ./output:/comfy/mnt/ComfyUI/output
     restart: unless-stopped
     environment:
       - WANTED_UID=1000


### PR DESCRIPTION
Updated the README with optional mappings for models, workflows, and outputs. This helps new Docker users set custom paths, allowing safe container reset(by deleting run folder) without losing important files.

**Also, thanks for creating the docker image ⭐.**