### PR TITLE
fix typo in 21-Triton.sh

### DIFF
--- a/userscripts_dir/21-Triton.sh
+++ b/userscripts_dir/21-Triton.sh
@@ -59,7 +59,7 @@ mkdir -p ${BUILD_BASE}
 if [ ! -d ${BUILD_BASE} ]; then error_exit "${BUILD_BASE} not found"; fi
 cd ${BUILD_BASE}
 
-dd="/comfy/mnt/src/${BUILD_BASE}/Triton"
+dd="/comfy/mnt/src/${BUILD_BASE}/triton"
 
 if [ -d $dd ]; then
   echo "Triton source already present, deleting $dd to force reinstallation"


### PR DESCRIPTION
code block to delete existing directory was not finding the dir due to upper case "T":
```
dd="/comfy/mnt/src/${BUILD_BASE}/Triton"

if [ -d $dd ]; then
  echo "Triton source already present, deleting $dd to force reinstallation"
  rm -rf $dd
fi
```
resulted in error:
```
++ Running user script: /userscripts_dir/21-Triton.sh
Checking if nvcc is available
Triton is installed with version 3.2.0
Triton version 3.2.0 is below minimum version 3.3, need to compile
Compiling Triton
fatal: destination path 'triton' already exists and is not an empty directory.
!! ERROR: User script (/userscripts_dir/21-Triton.sh) failed or exited with an error, stopping further processing
!! Exiting script (ID: 58)
!! ERROR: subscript failed
!! Exiting script (ID: 1)
```