### PR TITLE
Update 21-Triton.sh (Issue #69)

### DIFF
--- a/userscripts_dir/21-Triton.sh
+++ b/userscripts_dir/21-Triton.sh
@@ -76,6 +76,7 @@ if [ -d $dd ]; then
 fi
 git clone https://github.com/triton-lang/triton.git
 cd triton
-pip3 install -e python || error_exit "Failed to install Triton"
+pip3 install -r python/requirements.txt || error_exit "Failed to install Triton's build-time dependencies."
+pip3 install -e . || error_exit "Failed to install Triton."
 
 exit 0


### PR DESCRIPTION
See #69 

line 79 of the current script is incorrect.
```
pip3 install -e python || error_exit "Failed to install Triton"
```

According to the [Triton Github readme on build from source](https://github.com/triton-lang/triton/?tab=readme-ov-file#install-from-source) Should actually be:
```
pip3 install -r python/requirements.txt || error_exit "Failed to install Triton's build-time dependencies."
pip3 install -e . || error_exit "Failed to install Triton."
```