### PR TITLE
add check and remove of unintended install of onnxruntime instead of onnxruntime-gpu

### DIFF
--- a/userscripts_dir/11-onnxruntime-gpu.sh
+++ b/userscripts_dir/11-onnxruntime-gpu.sh
@@ -34,6 +34,26 @@ else
   echo "== Using pip"
 fi
 
+# --- START OF MODIFICATION ---
+echo "Checking for existing onnxruntime installations..."
+
+# Check if standard onnxruntime (CPU) is installed
+if pip show onnxruntime > /dev/null 2>&1; then
+    # Check if onnxruntime-gpu is ALSO installed
+    if pip show onnxruntime-gpu > /dev/null 2>&1; then
+        echo "Found BOTH onnxruntime and onnxruntime-gpu."
+        echo "Uninstalling both to ensure clean GPU installation..."
+        pip uninstall -y onnxruntime onnxruntime-gpu || error_exit "Failed to uninstall conflicting packages"
+    else
+        # Only standard onnxruntime is installed
+        echo "Found onnxruntime (CPU). Uninstalling it to replace with GPU version..."
+        pip uninstall -y onnxruntime || error_exit "Failed to uninstall onnxruntime"
+    fi
+else
+    echo "No conflicting 'onnxruntime' (CPU) package found. Proceeding..."
+fi
+# --- END OF MODIFICATION ---
+
 CMD="${PIP3_CMD} onnxruntime-gpu"
 echo "CMD: \"${CMD}\""
 ${CMD} || error_exit "Failed to install onnxruntime-gpu"


### PR DESCRIPTION
Some custom node requirements install unintentionally install `onnxruntime` instead of `onnxruntime-gpu`.
(onnxruntime used to have the gpu code in it as well, as far as i understand and is now a separate package)
If this is the case, the code in `onnxruntime` package is prioritised during workflow execution and can only find cpu.
Merely uninstalling onnxruntime doesnt seem to resolve it; you need to uninstall both and reinstall only the gpu version.

This PR does that check automatically, so it is even safe to keep in the userscripts after initial install, and it will check on each launch if `onnxruntime` is installed and only then it will attempt to uninstall.
If only `onnxruntime-gpu` is installed, the original behavior stays and pip/uv will exit with `requirements already satisfied`
