### PR TITLE
Add optional userscripts for common custom-node issues

### DIFF
--- a/userscripts_dir/03-clone_missing_nodes.sh
+++ b/userscripts_dir/03-clone_missing_nodes.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+# Pre-requisites (run first):
+# - None (runs before 05-customnodes_fixer.sh so cloned nodes get their
+#   requirements installed in the same container start)
+
+# Clone listed custom nodes into BASE_DIRECTORY/custom_nodes if not already
+# present. Designed to ensure "well-known missing" nodes are available so the
+# downstream 05-customnodes_fixer.sh picks up their requirements.txt.
+#
+# Configure via env var CLONE_MISSING_NODES (space-separated entries of
+# "<folder>|<git-url>[|<branch-or-tag>]"). If unset, the DEFAULT_NODES below
+# are used. Set CLONE_MISSING_NODES="" to disable entirely.
+
+# --- CONFIGURATION ---
+# Each entry: <folder>|<git-url>[|<branch-or-tag>]
+DEFAULT_NODES=(
+  "comfyui_controlnet_aux|https://github.com/Fannovel16/comfyui_controlnet_aux.git"
+)
+CLONE_MISSING_NODES="${CLONE_MISSING_NODES-__default__}"
+# ---------------------
+
+# --- COLOR CODES (for console)---
+LOG_ERR=$(printf '\033[0;41m') # White on RED BG
+LOG_WARN=$(printf '\033[0;33m') # Yellow
+LOG_OK=$(printf '\033[0;32m') # GREEN
+LOG_INFO=$(printf '\033[0m') # No Color
+NC=$(printf '\033[0m') # No Color
+# --------------------------------
+
+set -e
+
+error_exit() {
+  echo -n -e "${LOG_ERR}!! ERROR: ${NC}"
+  echo $*
+  echo "!! Exiting clone_missing_nodes script (ID: $$)"
+  exit 1
+}
+
+CUSTOM_NODES_DIR="${BASE_DIRECTORY:-/basedir}/custom_nodes"
+if [ ! -d "$CUSTOM_NODES_DIR" ]; then
+  error_exit "Custom nodes directory not found: $CUSTOM_NODES_DIR"
+fi
+
+if [ "$CLONE_MISSING_NODES" = "__default__" ]; then
+  entries=("${DEFAULT_NODES[@]}")
+  echo "${LOG_INFO}INFO:${NC} using default node list (override with CLONE_MISSING_NODES env var)"
+else
+  read -r -a entries <<< "$CLONE_MISSING_NODES"
+fi
+
+if [ "${#entries[@]}" -eq 0 ]; then
+  echo "${LOG_INFO}INFO:${NC} CLONE_MISSING_NODES is empty, nothing to do"
+  exit 0
+fi
+
+for entry in "${entries[@]}"; do
+  IFS='|' read -r folder url branch <<< "$entry"
+  target="$CUSTOM_NODES_DIR/$folder"
+
+  if [ -z "$folder" ] || [ -z "$url" ]; then
+    echo "${LOG_WARN}WARN:${NC} skipping malformed entry: '$entry' (expected <folder>|<url>[|<branch>])"
+    continue
+  fi
+
+  if [ -d "$target" ]; then
+    echo "${LOG_INFO}INFO:${NC} $folder already present, skipping clone"
+    continue
+  fi
+
+  # Respect .disabled marker (user may have intentionally removed the node)
+  if [ -d "$CUSTOM_NODES_DIR/.disabled/$folder" ]; then
+    echo "${LOG_WARN}WARN:${NC} $folder is disabled (.disabled/$folder), skipping clone"
+    continue
+  fi
+
+  echo "++ Cloning $folder from $url${branch:+ (branch/tag: $branch)}"
+  clone_args=(--depth 1)
+  if [ -n "$branch" ]; then
+    clone_args+=(--branch "$branch")
+  fi
+  if git clone "${clone_args[@]}" "$url" "$target"; then
+    echo "${LOG_OK}SUCCESS:${NC} cloned $folder"
+  else
+    echo "${LOG_ERR}FAIL:${NC} could not clone $folder (continuing)"
+    rm -rf "$target"
+  fi
+done
+
+exit 0

--- a/userscripts_dir/04-teacache_patch.sh
+++ b/userscripts_dir/04-teacache_patch.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# Pre-requisites (run first):
+# - 03-clone_missing_nodes.sh (only if teacache is among the cloned nodes;
+#   typically teacache is pre-installed by the user)
+
+# Workaround for https://github.com/welltop-cn/ComfyUI-TeaCache (unmaintained
+# since 2025-07): the upstream node imports `precompute_freqs_cis` from
+# `comfy.ldm.lightricks.model`, which was refactored into a model method in
+# newer ComfyUI releases. Without this patch, teacache fails with
+# `ImportError: cannot import name 'precompute_freqs_cis'`.
+#
+# We make the import soft (try/except, fall back to None) so teacache loads.
+# All non-LTXV model paths (Flux, Wan, Hunyuan, HiDream, Lumina2, etc.) keep
+# working. The LTXV teacache forward path remains upstream-broken and would
+# need a real port of the new API; it will error at runtime if selected.
+#
+# Idempotent: re-runs are no-ops once the patch marker is present, and the
+# patch is skipped entirely if the upstream symbol is restored in ComfyUI.
+
+# --- COLOR CODES (for console)---
+LOG_ERR=$(printf '\033[0;41m')
+LOG_WARN=$(printf '\033[0;33m')
+LOG_OK=$(printf '\033[0;32m')
+LOG_INFO=$(printf '\033[0m')
+NC=$(printf '\033[0m')
+# --------------------------------
+
+set -e
+
+error_exit() {
+  echo -n -e "${LOG_ERR}!! ERROR: ${NC}"
+  echo $*
+  echo "!! Exiting teacache_patch script (ID: $$)"
+  exit 1
+}
+
+CUSTOM_NODES_DIR="${BASE_DIRECTORY:-/basedir}/custom_nodes"
+target="$CUSTOM_NODES_DIR/teacache/nodes.py"
+marker="# TEACACHE_SOFT_IMPORT_PATCH"
+old_line="from comfy.ldm.lightricks.model import precompute_freqs_cis"
+
+if [ ! -f "$target" ]; then
+  echo "${LOG_INFO}INFO:${NC} teacache not installed at $target, skipping patch"
+  exit 0
+fi
+
+if grep -q "$marker" "$target"; then
+  echo "${LOG_INFO}INFO:${NC} teacache already patched, skipping"
+  exit 0
+fi
+
+if ! grep -qF "$old_line" "$target"; then
+  echo "${LOG_WARN}WARN:${NC} expected import line not found in teacache nodes.py; upstream may have changed, leaving file alone"
+  exit 0
+fi
+
+# Skip patching if the upstream symbol is back (future-proof against a
+# ComfyUI revert or a teacache update that uses the new API).
+lightricks_model="/comfy/mnt/ComfyUI/comfy/ldm/lightricks/model.py"
+if [ -f "$lightricks_model" ] && grep -qE '^def precompute_freqs_cis\b' "$lightricks_model"; then
+  echo "${LOG_INFO}INFO:${NC} comfy.ldm.lightricks.model.precompute_freqs_cis is available, patch not needed"
+  exit 0
+fi
+
+python3 - "$target" "$marker" <<'PY' || error_exit "Failed to apply teacache patch"
+import sys, pathlib
+path = pathlib.Path(sys.argv[1])
+marker = sys.argv[2]
+src = path.read_text()
+old = "from comfy.ldm.lightricks.model import precompute_freqs_cis"
+new = (
+    f"{marker}\n"
+    "try:\n"
+    "    from comfy.ldm.lightricks.model import precompute_freqs_cis\n"
+    "except ImportError:\n"
+    "    precompute_freqs_cis = None  # removed in newer ComfyUI; LTXV teacache path disabled\n"
+)
+if old not in src:
+    raise SystemExit("expected import line not found")
+path.write_text(src.replace(old, new, 1))
+PY
+
+echo "${LOG_OK}SUCCESS:${NC} patched teacache import to be soft (LTXV teacache path remains broken upstream)"
+exit 0

--- a/userscripts_dir/25-flash-attn.sh
+++ b/userscripts_dir/25-flash-attn.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Pre-requisites (run first):
+# - 00-nvidiaDev.sh
+
+# Install flash-attn (https://github.com/Dao-AILab/flash-attention).
+# Optional dependency for SeedVR2 and a handful of other custom nodes.
+#
+# Opt-in only — flash-attn rarely has prebuilt wheels for Blackwell
+# (sm_120 / RTX 50 series) and building from source is heavy. Default is
+# skip so container start stays fast.
+
+# --- CONFIGURATION ---
+INSTALL_FLASH_ATTN="${INSTALL_FLASH_ATTN:-false}"
+FORCE_REINSTALL="${FORCE_REINSTALL:-false}"
+# ---------------------
+
+# --- COLOR CODES (for console)---
+LOG_ERR=$(printf '\033[0;41m')
+LOG_WARN=$(printf '\033[0;33m')
+LOG_OK=$(printf '\033[0;32m')
+LOG_INFO=$(printf '\033[0m')
+NC=$(printf '\033[0m')
+# --------------------------------
+
+set -e
+
+error_exit() {
+  echo -n -e "${LOG_ERR}!! ERROR: ${NC}"
+  echo $*
+  echo "!! Exiting flash-attn script (ID: $$)"
+  exit 1
+}
+
+if [ "$INSTALL_FLASH_ATTN" != "true" ]; then
+  echo "${LOG_INFO}INFO:${NC} flash-attn install skipped (set INSTALL_FLASH_ATTN=true to enable)"
+  exit 0
+fi
+
+source /comfy/mnt/venv/bin/activate || error_exit "Failed to activate virtualenv"
+
+# --- CHECK EXISTING INSTALLATION ---
+if [ "$FORCE_REINSTALL" = "false" ]; then
+  if pip show flash-attn > /dev/null 2>&1; then
+    echo "${LOG_INFO}INFO:${NC} flash-attn is already installed."
+    echo "     (Set FORCE_REINSTALL=true to force reinstall)"
+    exit 0
+  fi
+else
+  echo "${LOG_INFO}INFO:${NC} FORCE_REINSTALL is true. Proceeding..."
+  pip uninstall -y flash-attn || true
+fi
+# -----------------------------------
+
+if ! command -v nvcc &> /dev/null; then
+  echo "${LOG_WARN}WARN:${NC} nvcc not found, flash-attn build needs CUDA toolkit; skipping"
+  exit 0
+fi
+
+# flash-attn 2.x requires --no-build-isolation so its setup.py can see the
+# installed torch. May build from source if no matching wheel is published.
+echo "++ Installing flash-attn (may build from source — this can take a while)"
+CMD="${PIP3_CMD} flash-attn --no-build-isolation"
+echo "CMD: \"${CMD}\""
+if ${CMD}; then
+  echo "${LOG_OK}SUCCESS:${NC} flash-attn installed"
+else
+  echo "${LOG_WARN}WARN:${NC} flash-attn install failed — it is optional, continuing"
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Adds three optional userscripts that fix common issues observed when starting the container with a populated `basedir/custom_nodes`:

- **`03-clone_missing_nodes.sh`** — clones listed custom nodes into `${BASE_DIRECTORY}/custom_nodes` if absent so that `05-customnodes_fixer.sh` picks up their `requirements.txt` on the same run. Configurable via `CLONE_MISSING_NODES` env var (entries of the form `<folder>|<url>[|<branch>]`), defaults to `comfyui_controlnet_aux` (widely needed dependency for several other nodes' preprocessor detection). Idempotent. Honors a `.disabled/<name>` marker so users can intentionally opt out.

- **`04-teacache_patch.sh`** — workaround for [welltop-cn/ComfyUI-TeaCache](https://github.com/welltop-cn/ComfyUI-TeaCache) (unmaintained since 2025-07): it imports `precompute_freqs_cis` from `comfy.ldm.lightricks.model`, which was refactored into a method on the model class in newer ComfyUI releases. Without this patch, teacache fails with `ImportError`. The script makes the import soft (try/except) so teacache loads — all non-LTXV model paths (Flux / Wan / Hunyuan / HiDream / Lumina2 / etc.) keep working. The LTXV teacache forward path remains upstream-broken; it would need a real port to the new API. Future-proof: skips automatically if the upstream symbol is restored.

- **`25-flash-attn.sh`** — optional flash-attn install for SeedVR2 and similar nodes. Gated behind `INSTALL_FLASH_ATTN=true` (default skip) since prebuilt wheels rarely exist for sm_120 / RTX 50-series and from-source builds are heavy. Matches the existing pattern in `13-nunchaku.sh` / `20-SageAttention2.sh` for `FORCE_REINSTALL`, color codes, and venv activation.

All three are idempotent, follow the existing `userscripts_dir` style (color codes, `error_exit`, `BASE_DIRECTORY` resolution), and exit cleanly when their target is absent or already in good shape.

## Validation

Two full clean-slate runs were performed with the same image (`mmartial/comfyui-nvidia-docker:ubuntu24_cuda13.1-latest`) and `basedir`, starting from a nuked `run/` directory in both cases. The only difference between runs was the presence of the three new scripts in `userscripts_dir/`.

### BEFORE (without the new scripts)

```
🚨 IMPORTANT: **comfyui_controlnet_aux** is not installed or not detectable!
Cannot import /basedir/custom_nodes/teacache module for custom nodes: cannot import name 'precompute_freqs_cis' from 'comfy.ldm.lightricks.model' (/comfy/mnt/ComfyUI/comfy/ldm/lightricks/model.py)
[/basedir/custom_nodes/comfy-mtb] | INFO -> Some nodes (2) could not be loaded.
   0.0 seconds (IMPORT FAILED): /basedir/custom_nodes/teacache
```

### AFTER (with the new scripts)

```
++ Running user script: /userscripts_dir/03-clone_missing_nodes.sh
SUCCESS: cloned comfyui_controlnet_aux
++ Running user script: /userscripts_dir/04-teacache_patch.sh
SUCCESS: patched teacache import to be soft (LTXV teacache path remains broken upstream)
...
++ Running user script: /userscripts_dir/25-flash-attn.sh
INFO: flash-attn install skipped (set INSTALL_FLASH_ATTN=true to enable)
...
[/basedir/custom_nodes/comfyui_controlnet_aux] | INFO -> Using ckpts path: /basedir/custom_nodes/comfyui_controlnet_aux/ckpts
[/basedir/custom_nodes/comfyui_controlnet_aux] | INFO -> Using ort providers: ['CUDAExecutionProvider', ...]
   0.7 seconds: /basedir/custom_nodes/teacache
   0.8 seconds: /basedir/custom_nodes/comfyui_controlnet_aux
```

The previously failing teacache import succeeds (`0.7 seconds: ...teacache`, no `IMPORT FAILED`) and `comfyui_controlnet_aux` is now cloned, has its requirements installed by `05-customnodes_fixer.sh` on the same start, and loads (`0.8 seconds: ...comfyui_controlnet_aux`).

The two remaining warnings that show up in both BEFORE and AFTER are intentional:
- `comfy-mtb Some nodes (2) could not be loaded` — the two MTB FILM nodes are upstream-deprecated and require TensorFlow; the recommended replacement (`comfyui-frame-interpolation`) is already installed.
- `Flash Attention ❌` in SeedVR2's optimizations check — `25-flash-attn.sh` is opt-in by design.

## Notes for maintainers

- All three scripts default to no-op when their preconditions aren't met (custom node absent, env var unset, package already installed, etc.) so adding them to a default `userscripts_dir` shouldn't affect users who don't need them.
- `03-clone_missing_nodes.sh` can be effectively disabled by setting `CLONE_MISSING_NODES=""` in the environment, if a user prefers to manage their own custom_nodes list.
- `04-teacache_patch.sh` was tested both with the broken upstream `precompute_freqs_cis` (current behavior) and with a simulated symbol restoration (script correctly skips patching).